### PR TITLE
#36 게시글 뷰 테스트 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,6 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
-/src/main/generated
+project_board/src/main/generated/project/board/domain/*
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,intellij,gradle,java

--- a/project_board/build.gradle
+++ b/project_board/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.data:spring-data-rest-hal-explorer' // 미리 만들어진 웹서비스 api 테스트용
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'

--- a/project_board/src/main/java/project/board/controller/ArticleController.java
+++ b/project_board/src/main/java/project/board/controller/ArticleController.java
@@ -1,0 +1,11 @@
+package project.board.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@RequestMapping("/articles")
+@Controller
+public class ArticleController {
+}

--- a/project_board/src/test/java/project/board/controller/ArticleControllerTest.java
+++ b/project_board/src/test/java/project/board/controller/ArticleControllerTest.java
@@ -1,0 +1,80 @@
+package project.board.controller;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 게시글")
+@WebMvcTest(ArticleController.class) // 테스트 대상이 되는 컨트롤러만 불러온다
+class ArticleControllerTest {
+
+    private final MockMvc mvc;
+
+    public ArticleControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Disabled("구현 중") // 단위 메소드들을 테스트에서 제외시킬 수 있다
+    @DisplayName("[view] [GET] 게시글 리스트 {게시판} 페이지 - 정상 호출")
+    @Test
+    public  void givenNothing_whenRequestingArticlesView_thenReturnArticlesView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/articles"))
+                .andExpect(status().isOk()) // 요청응답이 ok 인가?
+                .andExpect(content().contentType(MediaType.TEXT_HTML)) // 컨텐트 내용에 타입이 무엇인가?, view 라서 TEXT_HTML
+                .andExpect(view().name("articles/index")) // 여기에 뷰가 있어야 한다
+                .andExpect(model().attributeExists("articles")); // 이 뷰는 데이터가 있을 것이다 왜냐하면 이번페이지 게시글 목록이 보여야 하기 때문에 모델에트리뷰트로 밀어 넣어준다
+    }
+
+    @Disabled("구현 중")
+    @DisplayName("[view] [GET] 게시글 상세 페이지 - 정상 호출")
+    @Test
+    public  void givenNothing_whenRequestingArticleView_thenReturnArticleView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/articles/1"))
+                .andExpect(status().isOk()) // 요청응답이 ok 인가?
+                .andExpect(content().contentType(MediaType.TEXT_HTML)) // 컨텐트 내용에 타입이 무엇인가?, view 라서 TEXT_HTML
+                .andExpect(view().name("articles/detail"))
+                .andExpect(model().attributeExists("article")) // 이 뷰는 데이터가 있을 것이다 왜냐하면 이번페이지 게시글 목록이 보여야 하기 때문에 모델에트리뷰트로 밀어 넣어준다
+                .andExpect(model().attributeExists("articleComments"));
+    }
+
+    @Disabled("구현 중")
+    @DisplayName("[view] [GET] 게시글 검색 전용 페이지 - 정상 호출")
+    @Test
+    public  void givenNothing_whenRequestingArticleSearchView_thenReturnArticleSearchView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/articles/search"))
+                .andExpect(status().isOk()) // 요청응답이 ok 인가?
+                .andExpect(content().contentType(MediaType.TEXT_HTML)) // 컨텐트 내용에 타입이 무엇인가?, view 라서 TEXT_HTML
+                .andExpect(model().attributeExists("articles/search"));
+    }
+
+    @Disabled("구현 중")
+    @DisplayName("[view] [GET] 게시글 해시태그 검색 페이지 - 정상 호출")
+    @Test
+    public  void givenNothing_whenRequestingArticleHashtagSearchView_thenReturnArticleHashtagSearchView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/articles/search-hashtag"))
+                .andExpect(status().isOk()) // 요청응답이 ok 인가?
+                .andExpect(content().contentType(MediaType.TEXT_HTML)) // 컨텐트 내용에 타입이 무엇인가?, view 라서 TEXT_HTML
+                .andExpect(model().attributeExists("articles/search-hashtag"));
+    }
+
+
+}


### PR DESCRIPTION
기존 테스트를 실패한 'gradle.build'가 실패하여 배포 자동화에 악영향을 미치는 경우가 있음으로, 실패 테스트는 테스트 제외 처리하는 방향으로 정책을 잡아보기로 했다.
이에 기능 구현중인 유닛 테스트를 모두 '@Disabled' 처리

그 밖에 추가로 생각난 테스트 방법을 추가했다